### PR TITLE
optionally install python2-secrets for older runtime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,11 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['python2-secrets', 'cryptography', 'jsonschema'],
+    install_requires=[
+        'python2-secrets;python_version<"3.6"',
+        'cryptography',
+        'jsonschema',
+    ],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
install_requires can check platform or python version, only install python2-secrets for older python version which does not built-in.